### PR TITLE
Undefined name: r = self.http_request()

### DIFF
--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -375,7 +375,7 @@ class Database(object):
             payload = {
                 'name' : f
                 }
-            self.http_request(object_type='function',object_name=f, request = 'DELETE', payload=payload)
+            r = self.http_request(object_type='function',object_name=f, request = 'DELETE', payload=payload)
             msg = 'Function registration deletion status: %s' %(r.data.decode('utf-8'))
             logger.info(msg) 
     


### PR DESCRIPTION
__r__ is an undefined name on line 379 so this PR proposes to modify line 378 to create __r__ (mirroring lines 235 and 239).

[flake8](http://flake8.pycqa.org) testing of https://github.com/ibm-watson-iot/functions on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./iotfunctions/db.py:379:65: F821 undefined name 'r'
            msg = 'Function registration deletion status: %s' %(r.data.decode('utf-8'))
                                                                ^
./iotfunctions/preprocessor.py:486:80: F821 undefined name 'a'
            msg = 'Argument %s is has explicit json schema defined for it %s' %a, self.itemJsonSchema[arg]
                                                                               ^
./iotfunctions/preprocessor.py:1429:225: F821 undefined name 'sql'
                    msg = 'Unable to retrieve data from lookup table using %s. Check that database table exists and credentials are correct. Include data in your function definition to automatically create a lookup table.' %sql
                                                                                                                                                                                                                                ^
3     F821 undefined name 'r'
3
```