### PR TITLE
Travis CI: Upgrade pip and add a flake8 lint step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ python:
   - "3.6"
 # command to install dependencies
 install:
-  - pip install nose pylint
+  - pip install --upgrade pip
+  - pip install flake8 nose  # pylint
 # command to run tests
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - nosetests
 #  - find . -name "*.py" -exec pylint -E --disable=import-error '{}' +


### PR DESCRIPTION
Upgrades __pip-9.0.1__ --> __pip-19.0.2__ and then installs and runs [flake8](http://flake8.pycqa.org) tests to flag any Python syntax errors or undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
