### PR TITLE
Change text -> universal_newlines to support python 3.6

### DIFF
--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -591,7 +591,7 @@ class Database(object):
         logger.debug(msg)
        
         completedProcess = subprocess.run(['pip', 'install', '--process-dependency-links', '--upgrade', url],
-                               stderr=subprocess.STDOUT, stdout=subprocess.PIPE, text=True)
+                               stderr=subprocess.STDOUT, stdout=subprocess.PIPE, universal_newlines=True)
 
         if completedProcess.returncode == 0:
             logger.info('pip install for url %s was successful: \n %s' % (url, completedProcess.stdout))


### PR DESCRIPTION
keyword 'text' was introduced with python 3.7 as an alias for 'universal_newlines'. We still run with python < 3.7. The current bug does not affect the pipeline because the pipeline uses the corresponding function defined in analytics_service_pipeline packages which is already fixed.
