### PR TITLE
when registering a sample entity type for a postgresql tenant, use 'p…

### DIFF
--- a/iotfunctions/metadata.py
+++ b/iotfunctions/metadata.py
@@ -1823,7 +1823,11 @@ class EntityType(object):
             try:
                 table['schemaName'] = self.db.credentials['db2']['username']
             except KeyError:
-                raise KeyError('No db2 credentials found. Unable to register table.')
+                try:
+                    username = self.db.credentials["postgresql"]['username']
+                    table["schemaName"] = "public"
+                except KeyError:
+                    raise KeyError('No database credentials found. Unable to register table.')
         payload = [table]
         response = self.db.http_request(request='POST', object_type='entityType', object_name=self.name,
                                         payload=payload, raise_error=raise_error)


### PR DESCRIPTION
…ublic' as default schema


https://github.ibm.com/Watson-IoT/connection-service/issues/1838

This fixes an error where iotfunctions only looks for db2 credentials and fails to check for postgresql credentials during entity type registration