### PR TITLE
fix(db): tolerate the case where the dimension table might not yet exist

### DIFF
--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -1788,7 +1788,10 @@ class Database(object):
         table = self.get_table(table_name, schema)
         dim = None
         if dimension is not None:
-            dim = self.get_table(table_name=dimension, schema=schema)
+            try: # tolerate the case where the dimension table might not yet have been created
+                dim = self.get_table(table_name=dimension, schema=schema)
+            except (KeyError):
+                dim = None
 
         if column_names is None:
             if dim is None:


### PR DESCRIPTION
Query needs to quietly handle the cases where  the dimension table doesn't exist instead of exploding,
the dimension table isn't always guaranteed to be there by default