### PR TITLE
Added scope filter flag

### DIFF
--- a/iotfunctions/base.py
+++ b/iotfunctions/base.py
@@ -66,6 +66,7 @@ class BaseFunction(object):
     requires_input_items = True
     produces_output_items = True
     _allow_empty_df = False
+    is_scope_enabled = True # enables filtering by scope (details specified in the UI)
     # internal work variables set by AS job processing
     name = None  # name of function
     _entity_type = None  # EntityType object that this function belongs to

--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -1608,7 +1608,7 @@ class Database(object):
             payload = {'name': name, 'description': f.__doc__, 'category': category,
                        'moduleAndTargetName': module_and_target, 'url': package_url, 'input': input_list,
                        'output': output_list, 'incremental_update': True if category == 'AGGREGATOR' else None,
-                       'tags': tags}
+                       'tags': tags, 'scope': {'enabled': f.is_scope_enabled}}
 
             if not is_preinstalled:
 

--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -1625,7 +1625,7 @@ class Database(object):
         for p in pre_installed:
             query = "INSERT INTO CATALOG_FUNCTION (FUNCTION_ID, TENANT_ID," \
                     " NAME, DESCRIPTION, MODULE_AND_TARGET_NAME, URL, CATEGORY," \
-                    " INPUT, OUTPUT, INCREMENTAL_UPDATE, IMAGE)" \
+                    " INPUT, OUTPUT, INCREMENTAL_UPDATE, IMAGE, SCOPE)" \
                     " VALUES( CATALOG_FUNCTION_SEQ.nextval,'###_IBM_###',"
             query = query + "'%s'," % p['name']
             query = query + "'%s'," % p['description'].replace("'", '"')
@@ -1635,11 +1635,12 @@ class Database(object):
             query = query + "'%s'," % json.dumps(p['input'])
             query = query + "'%s'," % json.dumps(p['output'])
             query = query + str(p['incremental_update']) + ', '
-            query = query + 'NULL)'
+            query = query + "NULL,"
+            query = query + "'%s')" % json.dumps(p['scope'])
 
             sql = sql + query
             sql = sql + '\n'
-
+        
         return sql
 
     def register_module(self, module, url=None, raise_error=True, force_preinstall=False):


### PR DESCRIPTION
Enables [#644](https://github.ibm.com/wiotp/monitoring-dashboard/issues/644) by adding a flag in the catalog function registration indicating whether scope is enabled.

Scope is enabled by default (specified in BaseFunction), but can be overwritten when implementing a custom function. With this implementation, all functions (including Base and BIFs) will have scope enabled.