### PR TITLE
Initialize unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ GTAGS
 *.zip
 
 .pytest_cache
+__pycache__
 env/
 *.irx
 
@@ -80,6 +81,8 @@ _build
 dist
 doc/build
 doc/cdoc/build
+# python virtualenv
+venv
 # Egg metadata
 *.egg-info
 # The shelf plugin uses this dir

--- a/iotfunctions/bif.py
+++ b/iotfunctions/bif.py
@@ -122,7 +122,6 @@ class AlertExpression(BaseEvent):
         return df
 
     def execute(self, df):
-        c = self._entity_type.get_attributes_dict()
         df = df.copy()
         if '${' in self.expression:
             expr = re.sub(r"\$\{(\w+)\}", r"df['\1']", self.expression)
@@ -983,7 +982,6 @@ class PythonExpression(BaseTransformer):
         self.outputs = ['output_name']
 
     def execute(self, df):
-        c = self._entity_type.get_attributes_dict()
         df = df.copy()
         requested = list(self.get_input_items())
         msg = self.expression + ' .'

--- a/iotfunctions/bif.py
+++ b/iotfunctions/bif.py
@@ -122,6 +122,7 @@ class AlertExpression(BaseEvent):
         return df
 
     def execute(self, df):
+        c = self._entity_type.get_attributes_dict()
         df = df.copy()
         if '${' in self.expression:
             expr = re.sub(r"\$\{(\w+)\}", r"df['\1']", self.expression)
@@ -982,6 +983,7 @@ class PythonExpression(BaseTransformer):
         self.outputs = ['output_name']
 
     def execute(self, df):
+        c = self._entity_type.get_attributes_dict()
         df = df.copy()
         requested = list(self.get_input_items())
         msg = self.expression + ' .'

--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -1357,7 +1357,8 @@ class Database(object):
 
         return df
 
-    def read_sql_query(self, sql, parse_dates=None, index_col= None, requested_col_names=None, log_message=None, **kwargs):
+    def read_sql_query(self, sql, parse_dates=None, index_col=None, requested_col_names=None, log_message=None,
+                       **kwargs):
 
         if log_message is None:
             logger.debug('The following sql statement is executed: %s' % sql)
@@ -1640,7 +1641,7 @@ class Database(object):
 
             sql = sql + query
             sql = sql + '\n'
-        
+
         return sql
 
     def register_module(self, module, url=None, raise_error=True, force_preinstall=False):
@@ -2794,7 +2795,6 @@ class Database(object):
         if self.connection is not None:
             try:
                 self.connection.dispose()
-                logger.info('SQLAlchemy database connection successfully closed.')
             except Exception:
                 logger.warning('Error while closing sqlalchemy database connection.', exc_info=True)
             finally:

--- a/tests/unit/test_bif.py
+++ b/tests/unit/test_bif.py
@@ -73,11 +73,13 @@ class TestAlertExpression():
 
     def test_execute(self, sample_df, expression, text_log):
         alert_expression = bif.AlertExpression(expression=expression, alert_name=self.ALERT_NAME)
+        alert_expression._entity_type = MagicMock()
         sample_df_copy = sample_df.copy()
         alert_expression.trace_append = MagicMock(return_value=None)
 
         df = alert_expression.execute(sample_df)
 
+        assert alert_expression._entity_type.get_attributes_dict.call_count == 1
         assert self.ALERT_NAME in list(df.columns)
         assert sample_df_copy.equals(sample_df)
         alert_expression.trace_append.assert_called_once_with(text_log)
@@ -167,9 +169,11 @@ class TestPythonExpression():
         mocked_input_items.return_value = input_items
         sample_df_copy = sample_df.copy()
         py_exp = bif.PythonExpression(expression=expression, output_name=output_name)
+        py_exp._entity_type = MagicMock()
         
         df = py_exp.execute(sample_df)
 
+        assert py_exp._entity_type.get_attributes_dict.call_count == 1
         assert mocked_trace_append.call_count == 2
         assert output_name in list(df.columns)
         assert sample_df_copy.equals(sample_df)

--- a/tests/unit/test_bif.py
+++ b/tests/unit/test_bif.py
@@ -1,0 +1,158 @@
+# *****************************************************************************
+# Â© Copyright IBM Corp. 2018.  All Rights Reserved.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Apache V2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# *****************************************************************************
+
+
+import pytest
+from unittest.mock import MagicMock, patch
+import os
+import json
+import pandas as pd
+import numpy as np
+
+from iotfunctions import bif
+from iotfunctions import metadata
+
+def pytest_generate_tests(metafunc):
+    # called once per each test function
+    funcarglist = metafunc.cls.params[metafunc.function.__name__]
+    argnames = sorted(funcarglist[0])
+    metafunc.parametrize(
+        argnames, [[funcargs[name] for name in argnames] for funcargs in funcarglist]
+    )
+
+# empty object for mocks
+class Object():
+    pass
+
+EXPRESSION = "df['col1'] > 3"
+ALERT_NAME = "test_alert"
+
+@pytest.fixture()
+def alert_expression():
+    expr = bif.AlertExpression(expression=EXPRESSION, alert_name=ALERT_NAME)
+    expr._entity_type = Object()
+    return expr
+
+@pytest.fixture()
+def empty_df():
+    return pd.DataFrame()
+
+@pytest.fixture()
+def sample_df():
+    return func_sample_df()
+
+def func_sample_df():
+    d = {'col1': [1, 3, 4], 'col2': [1, 4, 2]}
+    return pd.DataFrame(d)
+
+
+class TestAlertExpression():
+    params = {
+        "test_init": [dict(expression=EXPRESSION, alert_name=ALERT_NAME)],
+        "test_calc": [{}],
+        "test_execute": [dict(expression=EXPRESSION, text_log="Expression (df['col1'] > 3). "),
+                         dict(expression="df['col2'] < 3", text_log="Expression (df['col2'] < 3). ")]
+    }
+
+    def test_init(self, expression, alert_name):
+        alert = bif.AlertExpression(expression=expression, alert_name=alert_name)
+        assert alert.expression == expression
+        assert alert.alert_name == alert_name
+
+    def test_calc(self, alert_expression, sample_df):
+        '''
+        unused function, shouldn't do anything
+        '''
+        same_df = alert_expression._calc(sample_df)
+        assert sample_df.equals(sample_df)
+
+    def test_execute(self, sample_df, expression, text_log):
+        alert_expression = bif.AlertExpression(expression=expression, alert_name=ALERT_NAME)
+        alert_expression._entity_type = Object()
+        sample_df_copy = sample_df.copy()
+        alert_expression._entity_type.get_attributes_dict = MagicMock(return_value={})
+        alert_expression.trace_append = MagicMock(return_value=None)
+
+        df = alert_expression.execute(sample_df)
+
+        assert ALERT_NAME in list(df.columns)
+        assert sample_df_copy.equals(sample_df)
+        alert_expression._entity_type.get_attributes_dict.assert_called_once()
+        alert_expression.trace_append.assert_called_once_with(text_log)
+        assert df[ALERT_NAME].fillna(False).equals(eval(expression))
+
+class TestCoalesce():
+    params = {
+        "test_init": [dict(data_items=["col1", "col2"], output_item="coalesce_output_item", expected_output="coalesce_output_item"),
+                      dict(data_items=["col1", "col2"], output_item=None, expected_output="output_item")],
+        "test_execute": [dict(data_items=["col1", "col2"], input_df=func_sample_df(), expected_output=[1,3,4]),
+                         dict(data_items=["col2", "col1"], input_df=func_sample_df(), expected_output=[1,4,2]),
+                         dict(data_items=["col1", "col2"], input_df=pd.DataFrame({'col1': [1, None, 4], 'col2': [1, 4, 2]}), expected_output=[1,4,4])]
+    }
+
+    def test_init(self, data_items, output_item, expected_output):
+        coalesce = bif.Coalesce(data_items=data_items, output_item=output_item)
+        assert coalesce.data_items == data_items
+        assert coalesce.output_item == expected_output
+
+    def test_execute(self, input_df, data_items, expected_output):
+        coalesce = bif.Coalesce(data_items=data_items, output_item="coalesce_output_item")
+
+        df = coalesce.execute(input_df)
+
+        assert coalesce.output_item in list(df.columns)
+        assert df[coalesce.output_item].array == expected_output
+
+class TestDateDifference():
+    params = {
+        "test_init": [dict(date_1="evt_timestamp_dim", date_2="evt_timestamp_dim", num_days="dd_num_days", expected_num_days="dd_num_days"),
+                      dict(date_1="evt_timestamp_dim", date_2="evt_timestamp_dim", num_days=None, expected_num_days="num_days")],
+        "test_execute": [{}]
+    }
+    def test_init(self, date_1, date_2, num_days, expected_num_days):
+        dd = bif.DateDifference(date_1=date_1, date_2=date_2, num_days=num_days)
+        assert dd.date_1 == date_1
+        assert dd.date_2 == date_2
+        assert dd.num_days == expected_num_days
+
+    def test_execute(self):
+        # TODO
+        pass
+
+
+class TestDeleteInputData():
+    params = {
+        "test_init": [dict(dummy_items=["col1", "col2"], older_than_days=5, output_item="did_output_item", expected_output="did_output_item"),
+                      dict(dummy_items=["col1", "col2"], older_than_days=4, output_item=None, expected_output="output_item")],
+        "test_execute": [{}]
+    }
+    def test_init(self, dummy_items, older_than_days, output_item, expected_output):
+        did = bif.DeleteInputData(dummy_items=dummy_items, older_than_days=older_than_days, output_item=output_item)
+        assert did.older_than_days == older_than_days
+        assert did.dummy_items == dummy_items
+        assert did.output_item == expected_output
+
+    def test_execute(self):
+        pass
+
+class PythonExpression():
+    params = {
+        "test_init": [{}],
+        "test_execute": [{}]
+    }
+
+    @patch('bif.PythonExpression.parse_expression')
+    def test_init(self, mocked):
+        py_exp = bif.PythonExpression(expression="", output_name="")
+        mocked.assert_called_once() 
+        pass
+
+    def test_execute(self):
+        pass


### PR DESCRIPTION
Initialize standard/framework for unit testing.

Currently only have several functions in `bif.py` tested. Plan is to move on to testing `pipeline.py`, `metadata.py`, and `db.py` next, as this PR is just a starting point.

~~Also: as I was testing, I found and removed several lines of code that seemed to be unused in `bif.py`: 
`c = self._entity_type.get_attributes_dict()`.
If these are actually necessary for the functioning of the pipeline, then we can easily revert this. If we revert these deletions, we'll just need to mock them for the tests.~~