### PR TITLE
issue1538

### DIFF
--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -925,7 +925,8 @@ class Database(object):
 
         return [column.key for column in table.columns]
 
-    def http_request(self, object_type, object_name, request, payload=None, object_name_2='', raise_error=False, ):
+    def http_request(self, object_type, object_name, request, payload=None, object_name_2='', raise_error=False, 
+                     sample_enity_type=False):
         """
         Make an api call to AS.
 
@@ -945,7 +946,8 @@ class Database(object):
             GET, POST, DELETE, PUT
         payload : dict
             Dictionary will be encoded as JSON
-
+        sample_enity_type : boolean
+            When true calls meta api will additional parameter
         """
         if object_name is None:
             object_name = ''
@@ -978,8 +980,12 @@ class Database(object):
             [base_meta_url, 'kpi', 'v1', self.tenant_id, 'entityType', object_name, object_type, object_name_2])
 
         self.url[('allEntityTypes', 'GET')] = '/'.join([base_meta_url, 'meta', 'v1', self.tenant_id, 'entityType'])
-        self.url[('entityType', 'POST')] = '/'.join(
-            [base_meta_url, 'meta', 'v1', self.tenant_id, object_type]) + '?createTables=true'
+        if sample_enity_type:
+            self.url[('entityType', 'POST')] = '/'.join(
+                [base_meta_url, 'meta', 'v1', self.tenant_id, object_type]) + '?createTables=true&sampleEntityType=true'
+        else:
+            self.url[('entityType', 'POST')] = '/'.join(
+                [base_meta_url, 'meta', 'v1', self.tenant_id, object_type]) + '?createTables=true'
         self.url[('entityType', 'GET')] = '/'.join(
             [base_meta_url, 'meta', 'v1', self.tenant_id, object_type, object_name])
 

--- a/iotfunctions/metadata.py
+++ b/iotfunctions/metadata.py
@@ -1899,7 +1899,7 @@ class EntityType(object):
                     raise KeyError('No database credentials found. Unable to register table.')
         payload = [table]
         response = self.db.http_request(request='POST', object_type='entityType', object_name=self.name,
-                                        payload=payload, raise_error=raise_error)
+                                        payload=payload, raise_error=raise_error, sample_entity_type=True)
 
         msg = 'Metadata registered for table %s ' % self.name
         logger.debug(msg)

--- a/iotfunctions/metadata.py
+++ b/iotfunctions/metadata.py
@@ -1833,7 +1833,7 @@ class EntityType(object):
         except Exception:
             logger.debug('Error populating dm_wiot_entity_list table.')
 
-    def register(self, publish_kpis=False, raise_error=False):
+    def register(self, publish_kpis=False, raise_error=False, sample_entity_type=False):
         """
         Register entity type so that it appears in the UI. Create a table for input data.
 
@@ -1899,7 +1899,7 @@ class EntityType(object):
                     raise KeyError('No database credentials found. Unable to register table.')
         payload = [table]
         response = self.db.http_request(request='POST', object_type='entityType', object_name=self.name,
-                                        payload=payload, raise_error=raise_error, sample_entity_type=True)
+                                        payload=payload, raise_error=raise_error, sample_entity_type=sample_entity_type)
 
         msg = 'Metadata registered for table %s ' % self.name
         logger.debug(msg)


### PR DESCRIPTION
adding `sampleEnityType` parameter to metadata api call when creating entity type table

new call will be
```python
POST /api/meta/v1/AnalyticsServiceDev/entityType?createTables=true&sampleEnityType=true 
```