### PR TITLE
fix for sklearn scalers built with version < 0.22

### DIFF
--- a/iotfunctions/metadata.py
+++ b/iotfunctions/metadata.py
@@ -2540,7 +2540,8 @@ class Model(object):
         try:
             result = self.estimator.transform(df[self.features])
         except Exception as trex:
-            logger.info('0.20 !!!')
+            logmsg = 'Caught exception likely caused by a model generated with sklearn of version < 0.22. Exception: '
+            logger.warning((logmsg + str(trex)))
             self.estimator._check_n_features(df[self.features], reset=True)
             result = self.estimator.transform(df[self.features])
             pass

--- a/iotfunctions/metadata.py
+++ b/iotfunctions/metadata.py
@@ -2535,7 +2535,16 @@ class Model(object):
         return self.estimator
 
     def transform(self, df):
-        result = self.estimator.transform(df[self.features])
+        result = None
+        # support sklearn 0.20 to 0.23
+        try:
+            result = self.estimator.transform(df[self.features])
+        except Exception as trex:
+            logger.info('0.20 !!!')
+            self.estimator._check_n_features(df[self.features], reset=True)
+            result = self.estimator.transform(df[self.features])
+            pass
+
         msg = 'transformed using model %s' % (self.name)
         logger.info(msg)
         return result


### PR DESCRIPTION
sklearn 0.22 and larger added an attribute to count the number of expected features and validates input data when called to transform or predict data using an sklearn model.
When an sklearn model built with older version is unpickled this attribute will be missing. The fix creates the missing attribute.

I installed sklearn 0.21.1, ran notebook MonitorAnomalyFunction to generate the scaling models
then installed sklearn 0.23.1, ran the notebook again to check and it turned out work

```
2021-02-03T17:49:39.977 INFO iotfunctions.dbtables.retrieve_model Model model.TEST_ENTITY_FOR_FFTBASEDGENERALIZEDANOMALYSCOREV2.FFTbasedGeneralizedAnomalyScoreV2.FFTAnomalyScore.MyRoom of size 1107 bytes has been retrieved from filesystem
2021-02-03T17:49:39.982 INFO iotfunctions.metadata.transform 0.20 !!!
2021-02-03T17:49:39.989 INFO iotfunctions.metadata.transform transformed using model model.TEST_ENTITY_FOR_FFTBASEDGENERALIZEDANOMALYSCOREV2.FFTbasedGeneralizedAnomalyScoreV2.FFTAnomalyScore.MyRoom
```