### PR TITLE
[patch] missing library

### DIFF
--- a/iotfunctions/bif.py
+++ b/iotfunctions/bif.py
@@ -29,6 +29,8 @@ from .loader import _generate_metadata
 from .ui import (UISingle, UIMultiItem, UIFunctionOutSingle, UISingleItem, UIFunctionOutMulti, UIMulti, UIExpression,
                  UIText, UIParameters)
 from .util import adjust_probabilities, reset_df_index, asList
+from ibm_watson_machine_learning import APIClient
+
 
 logger = logging.getLogger(__name__)
 PACKAGE_URL = 'git+https://github.com/ibm-watson-iot/functions.git@'

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pyarrow==3.0.0
 stumpy==1.5.1
 torch>=1.3.1
 statsmodels==0.11.1
+ibm-watson-machine-learning>=1.0.0


### PR DESCRIPTION
To perform an end-to-end testing in dev for issue https://github.ibm.com/wiotp/Maximo-Asset-Monitor/issues/2470 we need to add ibm-watson-machine-learning to support InvokeWMLModel from this PR: https://github.com/ibm-watson-iot/functions/pull/408.
Will require new pipeline build before I can test in dev. @pkohlmann do we rebuild the base image manually after merging into dev? 