### PR TITLE
[patch] handle case where output items is a string

### DIFF
--- a/iotfunctions/bif.py
+++ b/iotfunctions/bif.py
@@ -2842,7 +2842,10 @@ class InvokeWMLModel(BaseTransformer):
         self.whoami = 'InvokeWMLModel'
 
         self.input_items = input_items
-        self.output_items = output_items
+        if isinstance(output_items, str):
+            self.output_items = [output_items]
+        else:
+            self.output_items = output_items
         self.wml_auth = wml_auth
 
         self.deployment_id = None


### PR DESCRIPTION
When output_item is a str our function splits the name and creates unnecessary columns. Example below: MaxTemp is split into M, a, x, T, e, m, p, MaxTemp column. Currently, these columns should be deleted in persisted columns stage 
```
+----------------------------------------------------+-------+----------+--------+------------+-------------------+---------------------+--------------------+-----------+----------------------------+---------------------+------------+---------------------+---------------------+------------+-------------------------+---------------------+-----------------------------------+----------------------------+-----------------------+------------+-----------+--------------------+------------------+-----+-----+-----+-----+-----+-----+-----+-----------+
|                                                    |   acc |   torque |   load |   deviceid |   scheduled_maint |   unscheduled_maint |   firmware_upgrade |   testing | _timestamp                 | shift_day           |   shift_id | shift_start_date    | shift_end_date      | operator   | entity_data_generator   |   safety_stop_count |   percent_meeting_target_duration |   completed_movement_count |   abnormal_stop_count |   MeanTemp |   MinTemp | acc_high_5_alert   |   work_performed | M   | a   | x   | T   | e   | m   | p   |   MaxTemp |
|----------------------------------------------------+-------+----------+--------+------------+-------------------+---------------------+--------------------+-----------+----------------------------+---------------------+------------+---------------------+---------------------+------------+-------------------------+---------------------+-----------------------------------+----------------------------+-----------------------+------------+-----------+--------------------+------------------+-----+-----+-----+-----+-----+-----+-----+-----------|
| ('73004', Timestamp('2021-05-03 18:09:15.611117')) |   nan |      nan |    nan |      73004 |          nan      |             49.6167 |           nan      |  nan      | 2021-05-03 18:09:15.611117 | 2021-05-03 00:00:00 |          2 | 2021-05-03 14:00:00 | 2021-05-03 21:00:00 | nan        | True                    |                   3 |                          0.861909 |                          4 |                     0 |        nan |       nan |                    |              nan |     |     |     |     |     |     |     |       nan |
| ('73000', Timestamp('2021-05-06 18:09:15.611117')) |   nan |      nan |    nan |      73000 |          141.15   |            nan      |           nan      |  nan      | 2021-05-06 18:09:15.611117 | 2021-05-06 00:00:00 |          2 | 2021-05-06 14:00:00 | 2021-05-06 21:00:00 | Jeff H     | True                    |                  12 |                          0.904246 |                          0 |                     0 |        nan |       nan |                    |              nan |     |     |     |     |     |     |     |       nan |
| ('73003', Timestamp('2021-05-09 18:09:15.611117')) |   nan |      nan |    nan |      73003 |          nan      |            nan      |            91.3167 |  nan      | 2021-05-09 18:09:15.611117 | 2021-05-09 00:00:00 |          2 | 2021-05-09 14:00:00 | 2021-05-09 21:00:00 | Fred K     | True                    |                   0 |                          0.859115 |                          6 |                     0 |        nan |       nan |                    |              nan |     |     |     |     |     |     |     |       nan |
| ('73004', Timestamp('2021-05-12 18:09:15.611117')) |   nan |      nan |    nan |      73004 |          nan      |            nan      |           nan      |   65.0167 | 2021-05-12 18:09:15.611117 | 2021-05-12 00:00:00 |          2 | 2021-05-12 14:00:00 | 2021-05-12 21:00:00 | Jeff H     | True                    |                   0 |                          0.873306 |                          3 |                     0 |        nan |       nan |                    |              nan |     |     |     |     |     |     |     |       nan |
| ('73004', Timestamp('2021-05-14 08:54:33.209528')) |   nan |      nan |    nan |      73004 |           45.8333 |            nan      |           nan      |  nan      | 2021-05-14 08:54:33.209528 | 2021-05-14 00:00:00 |          1 | 2021-05-14 05:30:00 | 2021-05-14 14:00:00 | Jeff H     | True                    |                   5 |                          0.83824  |                          4 |                     0 |        nan |       nan |                    |              nan |     |     |     |     |     |     |     |       nan |
+----------------------------------------------------+-------+----------+--------+------------+-------------------+---------------------+--------------------+-----------+----------------------------+---------------------+------------+---------------------+---------------------+------------+-------------------------+---------------------+-----------------------------------+----------------------------+-----------------------+------------+-----------+--------------------+------------------+-----+-----+-----+-----+-----+-----+-----+-----------+ 
```