### PR TITLE
[patch] force version of certifi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pandas==1.4.3
 psycopg2-binary==2.9.5
 pyarrow==8.0.0
 pyod==1.0.0
-certifi>2023.7.22
+certifi>=2023.7.22
 requests==2.31.0
 ruptures==1.1.5
 scikit-learn==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ pandas==1.4.3
 psycopg2-binary==2.9.5
 pyarrow==8.0.0
 pyod==1.0.0
-requests==2.28.1
+certifi>2023.7.22
+requests==2.31.0
 ruptures==1.1.5
 scikit-learn==1.1.1
 scikit-image==0.19.2


### PR DESCRIPTION
wiotp/Maximo-Asset-Monitor#5716

certifi is pulled in by requests, but the default version (certifi-2023.5.7) is vunerable to CVE-2023-37920

As 2.31.0 is the most recent version of requests, the version of certifi needs to be explicitly set to avoid this vulnerability