### PR TITLE
[patch] downgrade scikit-learn to 1.3.0 for Predict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pyod==2.0.2
 certifi>=2024.7.04
 requests==2.32.2
 ruptures==1.1.9
-scikit-learn==1.5.0
+scikit-learn==1.3.0
 scikit-image==0.22.0
 scipy==1.11.4
 sqlalchemy==2.0.36


### PR DESCRIPTION
Refers to https://jsw.ibm.com/browse/MASMON-3550