### PR TITLE
[patch] Removed V1 API calls 9.1.x (MASMON-3684)

### DIFF
--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -831,7 +831,7 @@ class Database(object):
         try:
             # Get the ENTITY_TYPE table
             query, table = self.query('ENTITY_TYPE', 'IOTANALYTICS',
-                                      ['ENTITY_TYPE_ID'], filters={'Name': name})
+                                      ['ENTITY_TYPE_ID'], filters={'NAME': name})
             df = self.read_sql_query(query.statement)
             if not df.empty:
                 entity_type_id = df.iloc[0]['entity_type_id']
@@ -1040,8 +1040,6 @@ class Database(object):
 
         # self.url[('dataItem', 'PUT')] = '/'.join(
         #     [base_meta_url, 'kpi', 'v1', self.tenant_id, 'entityType', object_name, object_type, object_name_2])
-
-        # self.url[('allEntityTypes', 'GET')] = '/'.join([base_meta_url, 'meta', 'v1', self.tenant_id, 'entityType'])
 
         if sample_entity_type:
             self.url[('entityType', 'POST')] = '/'.join(

--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -1105,6 +1105,7 @@ class Database(object):
             [core_url, 'v2', 'core', 'deviceTypes', object_name, 'devices', object_type])
 
         self.url['devices', 'POST'] = '/'.join([core_url, 'v2', 'deviceTypes', object_name, object_type])
+        self.url[('deviceTypesSearch', 'POST')] = '/'.join([core_url, 'v2', 'core', 'deviceTypes', 'search'])
 
         encoded_payload = json.dumps(payload).encode('utf-8')
         headers = {'Content-Type': "application/json", 'X-api-key': self.credentials['as']['api_key'],
@@ -2831,6 +2832,20 @@ class Database(object):
         except AttributeError:
             msg = 'Constants deletion status: %s' % r
         logger.debug(msg)
+
+    def search_device_types(self):
+        """
+        Search device types.
+        """
+        payload = {
+            'search': '',
+            'filter': {}
+        }
+        try:
+            response = self.http_request(object_type='deviceTypesSearch', object_name=None, request='POST',payload=payload, raise_error=True)
+            return json.loads(response)
+        except Exception as e:
+            raise RuntimeError(f"Error occurred during search deviceType  ...")
 
     def write_frame(self, df, table_name, version_db_writes=False, if_exists='append', timestamp_col=None, schema=None,
                     chunksize=None, auto_index_name='_auto_index_'):

--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -828,14 +828,32 @@ class Database(object):
         # Warning: entity type name is not unique anymore. This function is used for backwards compatibility taken
         # the risk to return the wrong entity type. This function is only used in deprecated function 'GetEntityData'
         entity_type_id = None
-        for id, metadata in self.entity_type_metadata.items():
-            try:
-                if metadata['name'] == name:
-                    entity_type_id = id
-                    break
-            except Exception as e:
-                print(e)
+        try:
+            # Get the ENTITY_TYPE table
+            query, table = self.query('ENTITY_TYPE', 'IOTANALYTICS',
+                                      ['ENTITY_TYPE_ID'], filters={'Name': name})
+            df = self.read_sql_query(query.statement)
+            if not df.empty:
+                entity_type_id = df.iloc[0]['entity_type_id']
+                logger.debug(f"Found entity_type_id: {entity_type_id} for name: {name}")
+            else:
+                error_msg = f"No entity type found with name: '{name}'"
+                raise ValueError(error_msg)
+        except Exception as e:
+            error_msg = f"Error querying entity type by name '{name}': {e}"
+            raise RuntimeError(error_msg) from e
+        
         return self.get_entity_type(entity_type_id)
+
+    def get_engine_input(self, entity_type_id):
+        try:
+            response = self.http_request(object_type='input', object_name=str(entity_type_id),
+                                        request='GET', raise_error=True)
+            engine_input = json.loads(response)
+            logger.debug(f"Retrieved engine input for entity_type_id: {entity_type_id}")
+            return engine_input
+        except Exception as e:
+            raise RuntimeError(f"Error getting engine input for entity_type_id '{entity_type_id}': {e}")
 
     def get_entity_type(self, entity_type_id):
         """
@@ -844,16 +862,17 @@ class Database(object):
         """
         metadata = None
         try:
-            metadata = self.entity_type_metadata[entity_type_id]
-        except KeyError:
-            msg = 'No entity type with id  %s in the cached metadata.' % entity_type_id
+            # Use _get_engine_input to fetch metadata from API
+            metadata = self.get_engine_input(entity_type_id)
+        except Exception as e:
+            msg = 'No entity type with id  %s could be retrieved. Error: %s' % (entity_type_id, str(e))
             raise ValueError(msg)
 
         try:
             timestamp = metadata['metricTimestampColumn']
             schema = metadata['schemaName']
-            dim_table = metadata['dimensionTableName']
-        except TypeError:
+            dim_table = metadata['dimensionsTable']
+        except (TypeError, KeyError):
             try:
                 is_entity_type = metadata.is_entity_type
             except AttributeError:
@@ -865,10 +884,10 @@ class Database(object):
                 msg = 'Entity type %s not found in the database metadata' % entity_type_id
                 raise KeyError(msg)
         else:
-            entity = md.EntityType(name=metadata['name'], db=self,
+            entity = md.EntityType(name=metadata['resourceName'], db=self,
                                    **{'auto_create_table': False, '_timestamp': timestamp, '_db_schema': schema,
                                       '_entity_type_id': entity_type_id, '_dimension_table_name': dim_table,
-                                      'metric_table_name': metadata['metricTableName'], '_data_items': metadata.get('dataItemDto')})
+                                      'metric_table_name': metadata['metricsTableName'], '_data_items': metadata.get('dataItems')})
 
         return entity
 

--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -456,40 +456,11 @@ class Database(object):
             self.native_connection = None
             self.native_connection_dbi = None
 
-        # cache entity types
-        self.entity_type_metadata = {}
-
-        if entity_metadata is None:
-
-            # Load **all** entity types. This is required by Predict even when entity_type_id is None
-            metadata = self.http_request(object_type='allEntityTypes', object_name='', request='GET', payload={},
-                                         object_name_2='')
-            if metadata is not None:
-                try:
-                    metadata = json.loads(metadata)
-                    if metadata is None:
-                        msg = 'Unable to retrieve entity metadata from the server. Proceeding with limited metadata'
-                        logger.warning(msg)
-                    for m in metadata:
-                        self.entity_type_metadata[m['entityTypeId']] = m
-                except Exception:
-                    pass
-        else:
-            metadata = entity_metadata
-            if metadata.get('entityTypeId') is not None:
-                entity_type_id = metadata['entityTypeId']
-            self.entity_type_metadata[entity_type_id] = metadata
 
         # Figure out entity_type, entity_type_id and schema
         self.entity_type_id = None
         self.entity_type = None
         self.schema = None
-        if entity_type_id is not None:
-            self.entity_type_id = entity_type_id
-            metadata = self.entity_type_metadata.get(entity_type_id)
-            if metadata is not None:
-                self.entity_type = metadata.get('name')
-                self.schema = metadata.get('schemaName')
 
         # Create DBModelStore if it was not handed in
         if entity_type_id is not None:
@@ -1051,7 +1022,7 @@ class Database(object):
         # self.url[('dataItem', 'PUT')] = '/'.join(
         #     [base_meta_url, 'kpi', 'v1', self.tenant_id, 'entityType', object_name, object_type, object_name_2])
 
-        self.url[('allEntityTypes', 'GET')] = '/'.join([base_meta_url, 'meta', 'v1', self.tenant_id, 'entityType'])
+        # self.url[('allEntityTypes', 'GET')] = '/'.join([base_meta_url, 'meta', 'v1', self.tenant_id, 'entityType'])
 
         if sample_entity_type:
             self.url[('entityType', 'POST')] = '/'.join(

--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -845,6 +845,26 @@ class Database(object):
         
         return self.get_entity_type(entity_type_id)
 
+    def get_metadata_by_entity_type_name(self, name):
+        # this function is being used by predict, while migrating API V2 call,  created this
+        entity_type_id = None
+        try:
+            # Get the ENTITY_TYPE table
+            query, table = self.query('ENTITY_TYPE', 'IOTANALYTICS',
+                                      ['ENTITY_TYPE_ID'], filters={'NAME': name})
+            df = self.read_sql_query(query.statement)
+            if not df.empty:
+                entity_type_id = df.iloc[0]['entity_type_id']
+                logger.debug(f"Found entity_type_id: {entity_type_id} for name: {name}")
+            else:
+                error_msg = f"No entity type found with name: '{name}'"
+                raise ValueError(error_msg)
+        except Exception as e:
+            error_msg = f"Error querying entity type by name '{name}': {e}"
+            raise RuntimeError(error_msg) from e
+
+        return self.get_engine_input(entity_type_id)
+
     def get_engine_input(self, entity_type_id):
         try:
             response = self.http_request(object_type='input', object_name=str(entity_type_id),

--- a/iotfunctions/metadata.py
+++ b/iotfunctions/metadata.py
@@ -359,9 +359,6 @@ class EntityType(object):
             self._functions = []
         self._functions.extend(functions)
 
-        if name is not None and db is not None and not self.is_local:
-            db.entity_type_metadata[self.logical_name] = self
-
         logger.debug(('Initialized entity type %s'), str(self))
 
     def add_activity_table(self, name, activities, *args, **kwargs):


### PR DESCRIPTION
### Summary
- Removed bulk loading of all entity types during initialization
- Eliminated entity_type_metadata cache dictionary
- Moved get_engine_input() from api.py (pipeline) to db.py (functions)
### Fixes
- [MASMON-3684](https://jsw.ibm.com/browse/MASMON-3684)
### Test Details
**ENV**: IVT 9.1
Successful Pipeline run and Get Entity Data KPI 
<img width="1680" height="788" alt="image" src="https://github.com/user-attachments/assets/c64fed8b-5957-484f-a877-a50de1305874" />




