### PR TITLE
[patch] Removed V1 API calls 9.0.x (MASMON-3684)

### DIFF
--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -530,7 +530,6 @@ class Database(object):
         self.entity_type_id = None
         self.entity_type = None
         self.schema = None
-        self.resource_id = None
 
 
         # Create DBModelStore if it was not handed in
@@ -879,6 +878,10 @@ class Database(object):
         return self.get_entity_type(entity_type_id)
 
     def get_resource_id_by_entity_type_id(self, entity_type_id):
+        """
+        Needed because get_entity_type is used to train supervised models.
+        Used in train_lightgbm_regressor.py, train_simple_regressor.py
+        """
         try:
             query, table = self.query('ENTITY_TYPE', 'IOTANALYTICS',
                                       ['UUID'], filters={'ENTITY_TYPE_ID': [entity_type_id]})
@@ -1081,7 +1084,6 @@ class Database(object):
         # self.url[('dataItem', 'PUT')] = '/'.join(
         #     [base_meta_url, 'kpi', 'v1', self.tenant_id, 'entityType', object_name, object_type, object_name_2])
 
-        self.url[('allEntityTypes', 'GET')] = '/'.join([base_meta_url, 'meta', 'v1', self.tenant_id, 'entityType'])
 
         if sample_entity_type:
             self.url[('entityType', 'POST')] = '/'.join(

--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -849,6 +849,26 @@ class Database(object):
 
         return (package, module, class_name)
 
+    def get_metadata_by_entity_type_name(self, name):
+        # this function is being used by predict, while migrating API V2 call,  created this
+        entity_type_id = None
+        try:
+            # Get the ENTITY_TYPE table
+            query, table = self.query('ENTITY_TYPE', 'IOTANALYTICS',
+                                      ['ENTITY_TYPE_ID'], filters={'NAME': name})
+            df = self.read_sql_query(query.statement)
+            if not df.empty:
+                entity_type_id = df.iloc[0]['entity_type_id']
+                logger.debug(f"Found entity_type_id: {entity_type_id} for name: {name}")
+            else:
+                error_msg = f"No entity type found with name: '{name}'"
+                raise ValueError(error_msg)
+        except Exception as e:
+            error_msg = f"Error querying entity type by name '{name}': {e}"
+            raise RuntimeError(error_msg) from e
+
+        return self.get_engine_input(entity_type_id)
+
     def get_engine_input(self, uu_id):
         try:
             response = self.http_request(object_type='input', object_name=uu_id,
@@ -1127,6 +1147,7 @@ class Database(object):
             [core_url, 'v2', 'core', 'deviceTypes', object_name, 'devices', object_type])
         self.url['dimensions', 'PUT'] = '/'.join(
             [core_url, 'v2', 'core', 'deviceTypes', object_name, 'devices', object_type])
+        self.url[('deviceTypesSearch', 'POST')] = '/'.join([core_url, 'v2', 'core', 'deviceTypes', 'search'])
 
         encoded_payload = json.dumps(payload).encode('utf-8')
         headers = {'Content-Type': "application/json", 'X-api-key': self.credentials['as']['api_key'],
@@ -2851,6 +2872,21 @@ class Database(object):
         except AttributeError:
             msg = 'Constants deletion status: %s' % r
         logger.debug(msg)
+
+    def search_device_types(self):
+        """
+        Search device types.
+        """
+        payload = {
+            'search': '',
+            'filter': {}
+        }
+        try:
+            response = self.http_request(object_type='deviceTypesSearch', object_name=None, request='POST',
+                                         payload=payload, raise_error=True)
+            return json.loads(response)
+        except Exception as e:
+            raise RuntimeError(f"Error occurred during search deviceType  ... {e}")
 
     def write_frame(self, df, table_name, version_db_writes=False, if_exists='append', timestamp_col=None, schema=None,
                     chunksize=None, auto_index_name='_auto_index_'):

--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -525,40 +525,12 @@ class Database(object):
             self.native_connection = None
             self.native_connection_dbi = None
 
-        # cache entity types
-        self.entity_type_metadata = {}
-
-        if entity_metadata is None:
-
-            # Load **all** entity types. This is required by Predict even when entity_type_id is None
-            metadata = self.http_request(object_type='allEntityTypes', object_name='', request='GET', payload={},
-                                         object_name_2='')
-            if metadata is not None:
-                try:
-                    metadata = json.loads(metadata)
-                    if metadata is None:
-                        msg = 'Unable to retrieve entity metadata from the server. Proceeding with limited metadata'
-                        logger.warning(msg)
-                    for m in metadata:
-                        self.entity_type_metadata[m['entityTypeId']] = m
-                except Exception:
-                    pass
-        else:
-            metadata = entity_metadata
-            if metadata.get('entityTypeId') is not None:
-                entity_type_id = metadata['entityTypeId']
-            self.entity_type_metadata[entity_type_id] = metadata
 
         # Figure out entity_type, entity_type_id and schema
         self.entity_type_id = None
         self.entity_type = None
         self.schema = None
-        if entity_type_id is not None:
-            self.entity_type_id = entity_type_id
-            metadata = self.entity_type_metadata.get(entity_type_id)
-            if metadata is not None:
-                self.entity_type = metadata.get('name')
-                self.schema = metadata.get('schemaName')
+
 
         # Create DBModelStore if it was not handed in
         if entity_type_id is not None:

--- a/iotfunctions/metadata.py
+++ b/iotfunctions/metadata.py
@@ -358,8 +358,6 @@ class EntityType(object):
             self._functions = []
         self._functions.extend(functions)
 
-        if name is not None and db is not None and not self.is_local:
-            db.entity_type_metadata[self.logical_name] = self
 
         logger.debug(('Initialized entity type %s'), str(self))
 


### PR DESCRIPTION
### Summary

- Removed bulk loading of all entity types during initialization
- Eliminated entity_type_metadata cache dictionary
- Moved get_engine_input() from api.py (pipeline) to db.py (functions)

### Fixes

- [MASMON-3684](https://jsw.ibm.com/browse/MASMON-3684)

### Test Details
ENV: IVT 9.0

- Successful Pipeline run and Get Entity Data KPI
<img width="1609" height="704" alt="image" src="https://github.com/user-attachments/assets/eec6ef7c-60e1-43ec-b98f-5818eb2f0da9" />
