### PR TITLE
[patch] Removed V1 API calls 8.10.x (MASMON-3684)

### DIFF
--- a/iotfunctions/db.py
+++ b/iotfunctions/db.py
@@ -458,39 +458,12 @@ class Database(object):
             self.native_connection = None
             self.native_connection_dbi = None
 
-        # cache entity types
-        self.entity_type_metadata = {}
-
-        if entity_metadata is None:
-
-            metadata = self.http_request(object_type='allEntityTypes', object_name='', request='GET', payload={},
-                                         object_name_2='')
-            if metadata is not None:
-                try:
-                    metadata = json.loads(metadata)
-                    if metadata is None:
-                        msg = 'Unable to retrieve entity metadata from the server. Proceeding with limited metadata'
-                        logger.warning(msg)
-                    for m in metadata:
-                        self.entity_type_metadata[m['entityTypeId']] = m
-                except Exception:
-                    pass
-        else:
-            metadata = entity_metadata
-            if metadata.get('entityTypeId') is not None:
-                entity_type_id = metadata['entityTypeId']
-            self.entity_type_metadata[entity_type_id] = metadata
 
         # Figure out entity_type, entity_type_id and schema
         self.entity_type_id = None
         self.entity_type = None
         self.schema = None
-        if entity_type_id is not None:
-            self.entity_type_id = entity_type_id
-            metadata = self.entity_type_metadata.get(entity_type_id)
-            if metadata is not None:
-                self.entity_type = metadata.get('name')
-                self.schema = metadata.get('schemaName')
+
 
         # Create DBModelStore if it was not handed in
         if self.model_store is None and self.db_type in ['db2'] and self.entity_type_id is not None and self.schema is not None:
@@ -828,18 +801,53 @@ class Database(object):
 
         return (package, module, class_name)
 
+    def get_engine_input(self, uu_id):
+        try:
+            response = self.http_request(object_type='input', object_name=uu_id,
+                                         request='GET', raise_error=True)
+            engine_input = json.loads(response)
+            logger.debug(f"Retrieved engine input for resource_id: {uu_id}")
+            return engine_input
+        except Exception as e:
+            raise RuntimeError(f"Error getting engine input for resource_id '{uu_id}': {e}")
+
     def get_entity_type_by_name(self, name):
         # Warning: entity type name is not unique anymore. This function is used for backwards compatibility taken
         # the risk to return the wrong entity type. This function is only used in deprecated function 'GetEntityData'
-        entity_type_id = None
-        for id, metadata in self.entity_type_metadata.items():
-            try:
-                if metadata['name'] == name:
-                    entity_type_id = id
-                    break
-            except Exception as e:
-                print(e)
+        try:
+            query, table = self.query('ENTITY_TYPE', 'IOTANALYTICS',
+                                      ['ENTITY_TYPE_ID'], filters={'NAME': name})
+            df = self.read_sql_query(query.statement)
+            if not df.empty:
+                entity_type_id = df.iloc[0]['entity_type_id']
+                logger.debug(f"Found entity_type_id: {entity_type_id} for name: {name}")
+            else:
+                error_msg = f"No entity type found with name: '{name}'"
+                raise ValueError(error_msg)
+        except Exception as e:
+            error_msg = f"Error querying entity type by name '{name}': {e}"
+            raise RuntimeError(error_msg) from e
         return self.get_entity_type(entity_type_id)
+
+    def get_resource_id_by_entity_type_id(self, entity_type_id):
+        """
+        Needed because get_entity_type is used to train supervised models.
+        Used in train_lightgbm_regressor.py, train_simple_regressor.py
+        """
+        try:
+            query, table = self.query('ENTITY_TYPE', 'IOTANALYTICS',
+                                      ['UUID'], filters={'ENTITY_TYPE_ID': [entity_type_id]})
+            df = self.read_sql_query(query.statement)
+            if not df.empty:
+                uuid = df.iloc[0]['uuid']
+                logger.debug(f"Found uuid: {uuid} for entity id: {entity_type_id}")
+                return uuid
+            else:
+                error_msg = f"No entity type found with entity id: '{entity_type_id}'"
+                raise ValueError(error_msg)
+        except Exception as e:
+            error_msg = f"Error querying entity type by entity id '{entity_type_id}': {e}"
+            raise RuntimeError(error_msg) from e
 
     def get_entity_type(self, entity_type_id):
         """
@@ -847,17 +855,19 @@ class Database(object):
 
         """
         metadata = None
+        resource_id = None
         try:
-            metadata = self.entity_type_metadata[entity_type_id]
-        except KeyError:
-            msg = 'No entity type with id  %s in the cached metadata.' % entity_type_id
+            resource_id = self.get_resource_id_by_entity_type_id(entity_type_id)
+            metadata = self.get_engine_input(resource_id)
+        except Exception as e:
+            msg = 'No entity type with id  %s could be retrieved. Error: %s' % (resource_id, str(e))
             raise ValueError(msg)
 
         try:
             timestamp = metadata['metricTimestampColumn']
             schema = metadata['schemaName']
-            dim_table = metadata['dimensionTableName']
-        except TypeError:
+            dim_table = metadata['dimensionsTable']
+        except (TypeError, KeyError):
             try:
                 is_entity_type = metadata.is_entity_type
             except AttributeError:
@@ -869,10 +879,10 @@ class Database(object):
                 msg = 'Entity type %s not found in the database metadata' % entity_type_id
                 raise KeyError(msg)
         else:
-            entity = md.EntityType(name=metadata['name'], db=self,
+            entity = md.EntityType(name=metadata['resourceName'], db=self,
                                    **{'auto_create_table': False, '_timestamp': timestamp, '_db_schema': schema,
                                       '_entity_type_id': entity_type_id, '_dimension_table_name': dim_table,
-                                      'metric_table_name': metadata['metricTableName'], '_data_items': metadata.get('dataItemDto')})
+                                      'metric_table_name': metadata['metricsTableName'], '_data_items': metadata.get('dataItems')})
 
         return entity
 
@@ -1026,7 +1036,6 @@ class Database(object):
         # self.url[('dataItem', 'PUT')] = '/'.join(
         #     [base_meta_url, 'kpi', 'v1', self.tenant_id, 'entityType', object_name, object_type, object_name_2])
 
-        self.url[('allEntityTypes', 'GET')] = '/'.join([base_meta_url, 'meta', 'v1', self.tenant_id, 'entityType'])
 
         if sample_entity_type:
             self.url[('entityType', 'POST')] = '/'.join(

--- a/iotfunctions/metadata.py
+++ b/iotfunctions/metadata.py
@@ -358,8 +358,6 @@ class EntityType(object):
             self._functions = []
         self._functions.extend(functions)
 
-        if name is not None and db is not None and not self.is_local:
-            db.entity_type_metadata[self.logical_name] = self
 
         logger.debug(('Initialized entity type %s'), str(self))
 


### PR DESCRIPTION
### Summary

- Removed bulk loading of all entity types during initialization
- Eliminated entity_type_metadata cache dictionary
- Moved get_engine_input() from api.py (pipeline) to db.py (functions)

### Fixes

- [MASMON-3684](https://jsw.ibm.com/browse/MASMON-3684)

### Test Details
ENV: IVT 8.10

- Successful Pipeline run and Get Entity Data KPI
<img width="1653" height="669" alt="image" src="https://github.com/user-attachments/assets/9e5b7e58-80eb-4852-b60f-685349554958" />

