### PR TITLE
[patch] Update prophet package (9.1.x)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ lxml==5.3.1
 lightgbm==4.6.0
 nose2==0.15.1
 pandas==2.2.3
-prophet==1.1.6
+prophet==1.2.1
 pyarrow==19.0.0
 pyod==2.0.2
 certifi>=2025.4.26


### PR DESCRIPTION
### Summary

- Update prophet package to resolve the following error
- AttributeError: 'Prophet' object has no attribute 'stan_backend'

### Fixes

- [MASMON-5726](https://jsw.ibm.com/browse/MASMON-5726)

### Test Details

- Successful run test_prophet_forecaster.py
<img width="1646" height="512" alt="image" src="https://github.com/user-attachments/assets/90e01db3-821e-402d-9860-ec5051c2865d" />