### PR TITLE
[patch] Update prophet package (8.10.x)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ lxml==5.3.1
 lightgbm==4.6.0
 nose2==0.15.1
 pandas==2.2.3
-prophet==1.1.6
+prophet==1.2.1
 pyarrow==19.0.0
 # pyod==2.0.2
 certifi>=2025.4.26


### PR DESCRIPTION
### Summary

- Update prophet package to resolve the following error
- AttributeError: 'Prophet' object has no attribute 'stan_backend'

### Fixes

- [MASMON-5726](https://jsw.ibm.com/browse/MASMON-5726)

### Test Details

- There is no Prophet Forecaster or test so won't affect anything
