### PR TITLE
[patch] updated protobuf version to 5.29.6 (9.0.x)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ tabulate==0.9.0
 # torch==2.2.0 : installation moved to Dockerfile
 transformers==4.57.6
 urllib3==2.6.3
-protobuf==4.25.3
+protobuf==5.29.6


### PR DESCRIPTION
**Summary:** Updated protobuf version to remediate the vulnerability: CVE-2026-0994, CVE-2025-4565
 
**Jira:** [MASMON-4305](https://jsw.ibm.com/browse/MASMON-4305)