### PR TITLE
[patch] Upgrade transformers to version 5.3.0 (9.0.x)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ stumpy==1.13.0
 numpy==2.0.2
 tabulate==0.9.0
 # torch==2.2.0 : installation moved to Dockerfile
-transformers==4.57.6
+transformers==5.3.0
 urllib3==2.6.3
 protobuf==5.29.6


### PR DESCRIPTION
**Summary:** Updated transformers version to remediate the vulnerability: CVE-2025-14920, CVE-2025-14921, CVE-2025-14926, CVE-2025-14927
 
**Jira:** [MASMON-5450](https://jsw.ibm.com/browse/MASMON-5450)